### PR TITLE
Add PNG support to CLI build output

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import builtins
+import os
+import struct
+import zlib
 from dataclasses import dataclass
 from typing import Iterable, List, Tuple
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
 def new(mode: str, size: Tuple[int, int], color: int = 255) -> "Image":
@@ -12,6 +18,11 @@ def new(mode: str, size: Tuple[int, int], color: int = 255) -> "Image":
 
 
 def open(path: str) -> "Image":
+    with builtins.open(path, "rb") as handle:
+        signature = handle.read(len(PNG_SIGNATURE))
+        if signature == PNG_SIGNATURE:
+            return _open_png(handle)
+
     with builtins.open(path, "r", encoding="utf-8") as handle:
         header = handle.readline().strip()
         if header != "P2":
@@ -62,12 +73,18 @@ class Image:
         return Image(mode=self.mode, width=right - left, height=lower - upper, pixels=new_pixels)
 
     def save(self, path: str) -> None:
+        _, ext = os.path.splitext(path)
+        if ext.lower() == ".png":
+            with builtins.open(path, "wb") as handle:
+                _save_png(self, handle)
+            return
+
         with builtins.open(path, "w", encoding="utf-8") as handle:
             handle.write("P2\n")
             handle.write(f"{self.width} {self.height}\n")
             handle.write("255\n")
             for row in self.pixels:
-                handle.write(" ".join(str(min(255, max(0, int(value)))) for value in row) + "\n")
+                handle.write(" ".join(str(_clamp_to_byte(value)) for value in row) + "\n")
 
     def load(self) -> List[List[int]]:
         return self.pixels
@@ -84,3 +101,91 @@ class Image:
         for row in self.pixels:
             for value in row:
                 yield value
+
+
+def _clamp_to_byte(value: int) -> int:
+    return max(0, min(255, int(value)))
+
+
+def _write_png_chunk(handle, chunk_type: bytes, data: bytes) -> None:
+    handle.write(struct.pack(">I", len(data)))
+    handle.write(chunk_type)
+    handle.write(data)
+    crc = zlib.crc32(chunk_type)
+    crc = zlib.crc32(data, crc) & 0xFFFFFFFF
+    handle.write(struct.pack(">I", crc))
+
+
+def _save_png(image: Image, handle) -> None:
+    handle.write(PNG_SIGNATURE)
+    ihdr = struct.pack(">IIBBBBB", image.width, image.height, 8, 0, 0, 0, 0)
+    _write_png_chunk(handle, b"IHDR", ihdr)
+
+    raw_data = bytearray()
+    for row in image.pixels:
+        raw_data.append(0)
+        raw_data.extend(_clamp_to_byte(value) for value in row)
+    compressed = zlib.compress(bytes(raw_data))
+    _write_png_chunk(handle, b"IDAT", compressed)
+    _write_png_chunk(handle, b"IEND", b"")
+
+
+def _open_png(handle) -> Image:
+    width = height = None
+    bit_depth = color_type = None
+    idat_data = bytearray()
+
+    while True:
+        length_bytes = handle.read(4)
+        if len(length_bytes) != 4:
+            raise ValueError("Truncated PNG file")
+        length = struct.unpack(">I", length_bytes)[0]
+        chunk_type = handle.read(4)
+        if len(chunk_type) != 4:
+            raise ValueError("Truncated PNG file")
+        data = handle.read(length)
+        if len(data) != length:
+            raise ValueError("Truncated PNG file")
+        crc_bytes = handle.read(4)
+        if len(crc_bytes) != 4:
+            raise ValueError("Truncated PNG file")
+        expected_crc = struct.unpack(">I", crc_bytes)[0]
+        crc = zlib.crc32(chunk_type)
+        crc = zlib.crc32(data, crc) & 0xFFFFFFFF
+        if crc != expected_crc:
+            raise ValueError("Corrupted PNG file")
+
+        if chunk_type == b"IHDR":
+            width, height, bit_depth, color_type, compression, filter_method, interlace = struct.unpack(
+                ">IIBBBBB", data
+            )
+            if bit_depth != 8 or color_type != 0:
+                raise ValueError("Unsupported PNG color type")
+            if compression != 0 or filter_method != 0 or interlace != 0:
+                raise ValueError("Unsupported PNG compression settings")
+        elif chunk_type == b"IDAT":
+            idat_data.extend(data)
+        elif chunk_type == b"IEND":
+            break
+
+    if width is None or height is None or bit_depth is None or color_type is None:
+        raise ValueError("Incomplete PNG file")
+
+    decompressed = zlib.decompress(bytes(idat_data))
+    stride = width
+    expected_length = (stride + 1) * height
+    if len(decompressed) != expected_length:
+        raise ValueError("Unexpected PNG data length")
+
+    pixels: List[List[int]] = []
+    offset = 0
+    for _ in range(height):
+        filter_type = decompressed[offset]
+        offset += 1
+        if filter_type != 0:
+            raise ValueError("Unsupported PNG filter type")
+        row = list(decompressed[offset : offset + stride])
+        offset += stride
+        pixels.append(row)
+
+    return Image(mode="L", width=width, height=height, pixels=pixels)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
    ```bash
    python -m omr.cli build template.json sheet.png
    ```
+   The renderer inspects the destination extension: ``.png`` writes a
+   standards-compliant 8-bit grayscale PNG, while other suffixes fall back to an
+   ASCII PGM stream for compatibility with minimal environments.
 3. After collecting responses, scan the sheet at 300 DPI or higher with even
    lighting and minimal skew. Ensure bubbles are clearly filled with dark ink.
 4. Grade the scan and inspect the results:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from PIL import Image, ImageDraw
 
-from omr import cli, template
+from omr import builder, cli, template
 
 
 def _write_template(path: Path) -> None:
@@ -39,6 +39,14 @@ def test_cli_build_command(tmp_path):
     exit_code = cli.main(["build", str(template_path), str(output_path), "--dpi", "150"])
     assert exit_code == 0
     assert output_path.exists()
+
+    payload = output_path.read_bytes()
+    assert payload.startswith(b"\x89PNG\r\n\x1a\n")
+
+    reopened = Image.open(str(output_path))
+    template_obj = template.Template.load(str(template_path))
+    expected_size = builder.sheet_dimensions(template_obj, dpi=150)
+    assert reopened.size == expected_size
 
 
 def test_cli_grade_command(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- extend the stub PIL module to write and read minimal 8-bit grayscale PNG files
- update CLI regression test to verify PNG signature and reopen via PIL
- document that the build command now emits PNG files for .png destinations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3598b5948832e8f7adb3577d596e9