### PR TITLE
Add web dashboard for OMR workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@
 High-quality scans should maintain bubble edges without heavy compression to
 ensure the evaluator can distinguish filled and unfilled bubbles.
 
+## Web dashboard
+
+A browser-based dashboard is available for non-technical users who prefer
+interacting with the toolkit visually. Install the dependencies and launch the
+server with:
+
+```bash
+python -m omr.webapp
+```
+
+The application exposes three workflows from a single page:
+
+- **Render** – upload a template JSON file, pick a DPI, and download the rendered sheet.
+- **Grade** – upload a template and scanned response to see detected answers and save the JSON summary.
+- **Demo** – produce the sample template, filled sheet, and evaluation overlay with one click.
+
+Generated artefacts are written under `artifacts/webapp/` and are available via
+download links directly in the UI.
+
 ## Modern demo workflow
 
 To explore the full pipeline end-to-end, including a modern styled sheet,

--- a/omr/templates/base.html
+++ b/omr/templates/base.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title or "OMR Toolkit" }}</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+        margin: 0;
+        background: #f5f6fa;
+        color: #222;
+      }
+      header {
+        background: #283593;
+        color: #fff;
+        padding: 1.5rem 0;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      }
+      .container {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 1.5rem;
+      }
+      nav ul {
+        display: flex;
+        gap: 1rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      nav a {
+        color: #fff;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      nav a.active {
+        text-decoration: underline;
+      }
+      main {
+        padding: 2rem 0 3rem;
+      }
+      form {
+        background: #fff;
+        padding: 1.5rem;
+        border-radius: 8px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin-top: 1rem;
+      }
+      input[type="file"],
+      input[type="text"],
+      input[type="number"] {
+        margin-top: 0.5rem;
+        width: 100%;
+      }
+      input[type="submit"] {
+        margin-top: 1.5rem;
+        background: #3949ab;
+        color: #fff;
+        border: none;
+        padding: 0.75rem 1.5rem;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 1rem;
+      }
+      input[type="submit"]:hover {
+        background: #303f9f;
+      }
+      .errors {
+        margin-bottom: 1rem;
+        padding: 1rem;
+        border-radius: 6px;
+        background: #ffebee;
+        color: #b71c1c;
+      }
+      .result {
+        margin-top: 2rem;
+        background: #fff;
+        padding: 1.5rem;
+        border-radius: 8px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      }
+      .file-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+      }
+      .file-card {
+        border: 1px solid #e0e0e0;
+        border-radius: 6px;
+        padding: 1rem;
+        background: #fafafa;
+      }
+      .file-card a {
+        display: inline-block;
+        margin-right: 0.5rem;
+        color: #283593;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+      }
+      th, td {
+        border: 1px solid #ddd;
+        padding: 0.5rem 0.75rem;
+        text-align: left;
+      }
+      th {
+        background: #eef2ff;
+      }
+      .preview-image {
+        max-width: 100%;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        margin-top: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <h1>OMR Toolkit</h1>
+        <nav>
+          <ul>
+            <li><a href="{{ url_for('index') }}" class="{% if active_page == 'home' %}active{% endif %}">Dashboard</a></li>
+            <li><a href="{{ url_for('build_sheet') }}" class="{% if active_page == 'build' %}active{% endif %}">Render</a></li>
+            <li><a href="{{ url_for('grade_sheet') }}" class="{% if active_page == 'grade' %}active{% endif %}">Grade</a></li>
+            <li><a href="{{ url_for('demo_assets') }}" class="{% if active_page == 'demo' %}active{% endif %}">Demo</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <div class="container">
+        {% block content %}{% endblock %}
+      </div>
+    </main>
+  </body>
+</html>

--- a/omr/templates/build.html
+++ b/omr/templates/build.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Render a Template</h2>
+  <p>Provide a template JSON file and configure rendering options to create a printable sheet.</p>
+  {% if errors %}
+    <div class="errors">
+      <ul>
+        {% for error in errors %}<li>{{ error }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  <form method="post" enctype="multipart/form-data">
+    <label for="template_file">Template JSON</label>
+    <input type="file" id="template_file" name="template_file" accept="application/json" required />
+
+    <label for="dpi">DPI</label>
+    <input type="number" id="dpi" name="dpi" min="75" step="1" value="{{ form_values.dpi }}" required />
+
+    <label>
+      <input type="checkbox" name="show_option_guides" {% if form_values.show_option_guides %}checked{% endif %} />
+      Include option letters inside each bubble
+    </label>
+
+    <input type="submit" value="Render sheet" />
+  </form>
+
+  {% if result %}
+    <div class="result">
+      <h3>Rendered sheet</h3>
+      <p>
+        Template <strong>{{ result.template_name }}</strong> rendered at
+        <strong>{{ result.dpi }} DPI</strong>.
+      </p>
+      <p>
+        <a href="{{ result.download_url }}">Download PNG</a>
+        <a href="{{ result.preview_url }}" target="_blank" rel="noopener">Open in new tab</a>
+      </p>
+      <img class="preview-image" src="{{ result.preview_url }}" alt="Rendered OMR sheet preview" />
+    </div>
+  {% endif %}
+{% endblock %}

--- a/omr/templates/demo.html
+++ b/omr/templates/demo.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Generate Demo Artefacts</h2>
+  <p>Create a modern sample template, filled sheet, and evaluation outputs for experimentation.</p>
+  {% if errors %}
+    <div class="errors">
+      <ul>
+        {% for error in errors %}<li>{{ error }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  <form method="post">
+    <label for="seed">Random seed</label>
+    <input type="number" id="seed" name="seed" value="{{ form_values.seed }}" required />
+    <input type="submit" value="Generate demo" />
+  </form>
+
+  {% if result %}
+    <div class="result">
+      <h3>Demo bundle ready</h3>
+      <p>
+        Assets generated in <code>{{ result.base_dir }}</code> using seed <strong>{{ result.seed }}</strong>.
+      </p>
+      <div class="file-list">
+        {% for file in result.files %}
+          <div class="file-card">
+            <h4>{{ file.label }}</h4>
+            <p><code>{{ file.path }}</code></p>
+            <p>
+              <a href="{{ file.download_url }}">Download</a>
+              <a href="{{ file.preview_url }}" target="_blank" rel="noopener">Open</a>
+            </p>
+            {% if file.preview_url.endswith('.png') %}
+              <img class="preview-image" src="{{ file.preview_url }}" alt="{{ file.label }} preview" />
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/omr/templates/grade.html
+++ b/omr/templates/grade.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Grade a Scanned Sheet</h2>
+  <p>Upload the template and a scanned sheet image to evaluate which bubbles were marked.</p>
+  {% if errors %}
+    <div class="errors">
+      <ul>
+        {% for error in errors %}<li>{{ error }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  <form method="post" enctype="multipart/form-data">
+    <label for="template_file">Template JSON</label>
+    <input type="file" id="template_file" name="template_file" accept="application/json" required />
+
+    <label for="image_file">Scanned sheet image</label>
+    <input type="file" id="image_file" name="image_file" accept="image/*" required />
+
+    <label for="threshold">Fill threshold (0-1)</label>
+    <input type="text" id="threshold" name="threshold" value="{{ form_values.threshold }}" required />
+
+    <input type="submit" value="Evaluate" />
+  </form>
+
+  {% if result %}
+    <div class="result">
+      <h3>Evaluation summary</h3>
+      <p>
+        Template <strong>{{ result.template_name }}</strong> processed with a threshold of
+        <strong>{{ result.threshold }}</strong>.
+      </p>
+      <p>
+        Detected marks: <strong>{{ result.total_marked }}</strong> of
+        <strong>{{ result.total_bubbles }}</strong> bubbles.
+      </p>
+      <p>
+        <a href="{{ result.download_url }}">Download JSON results</a>
+        <a href="{{ result.raw_url }}" target="_blank" rel="noopener">View JSON</a>
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Question</th>
+            <th>Detected selections</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entry in result.summary %}
+            <tr>
+              <td>{{ entry.question }}</td>
+              <td>
+                {% if entry.options %}
+                  {{ entry.options | join(', ') }}
+                {% else %}
+                  <em>No marks detected</em>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/omr/templates/index.html
+++ b/omr/templates/index.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+  <section>
+    <h2>Welcome</h2>
+    <p>
+      Use this dashboard to render printable OMR sheets, grade scanned responses,
+      and generate a complete demonstration bundle without needing the command line.
+    </p>
+  </section>
+  <section class="result">
+    <h3>Available workflows</h3>
+    <ul>
+      <li><strong>Render:</strong> Upload a template JSON file to produce a printable sheet PNG.</li>
+      <li><strong>Grade:</strong> Upload a template and a scanned sheet to evaluate detected marks.</li>
+      <li><strong>Demo:</strong> Generate a ready-to-use example pack with synthetic responses.</li>
+    </ul>
+    <p>Choose an option from the navigation above to get started.</p>
+  </section>
+{% endblock %}

--- a/omr/webapp.py
+++ b/omr/webapp.py
@@ -1,0 +1,255 @@
+"""Flask web interface for the OMR toolkit."""
+from __future__ import annotations
+
+import io
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from flask import Flask, Response, render_template, request, url_for
+from PIL import Image
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+from . import builder, demo, evaluator, template
+
+DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parent.parent / "artifacts" / "webapp"
+
+
+def create_app(output_dir: Path | None = None) -> Flask:
+    """Create and configure the Flask application."""
+
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "omr-webapp"
+    resolved_output = Path(output_dir) if output_dir is not None else DEFAULT_OUTPUT_DIR
+    resolved_output.mkdir(parents=True, exist_ok=True)
+    app.config["OUTPUT_DIR"] = resolved_output
+
+    def _create_run_dir(feature: str) -> Path:
+        timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S-%f")
+        run_dir = resolved_output / feature / timestamp
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    def _relative_to_output(path: Path) -> str:
+        return str(path.relative_to(resolved_output))
+
+    def _serve_path(filename: str, *, as_attachment: bool = False) -> Response:
+        from flask import send_from_directory
+
+        return send_from_directory(
+            resolved_output,
+            filename,
+            as_attachment=as_attachment,
+            max_age=0,
+        )
+
+    def _parse_template(upload: FileStorage) -> template.Template:
+        data = upload.read()
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("Template must be UTF-8 encoded JSON") from exc
+        return template.Template.from_json(text)
+
+    def _build_question_summary(
+        tmpl: template.Template, result: evaluator.EvaluationResult
+    ) -> List[Dict[str, Iterable[str]]]:
+        summary: List[Dict[str, Iterable[str]]] = []
+        for question in tmpl.iter_questions():
+            answers = result.answers_for_question(question)
+            filled = sorted(option for option, marked in answers.items() if marked)
+            summary.append({"question": question, "options": filled})
+        return summary
+
+    @app.route("/")
+    def index() -> str:
+        return render_template(
+            "index.html", title="OMR Toolkit Dashboard", active_page="home"
+        )
+
+    @app.route("/build", methods=["GET", "POST"])
+    def build_sheet() -> str:
+        errors: List[str] = []
+        result_context: Dict[str, object] | None = None
+        dpi_value = request.form.get("dpi", "300")
+        show_guides = request.form.get("show_option_guides") == "on"
+
+        if request.method == "POST":
+            upload = request.files.get("template_file")
+            if upload is None or upload.filename == "":
+                errors.append("A template JSON file is required.")
+            try:
+                dpi = int(dpi_value)
+                if dpi <= 0:
+                    raise ValueError
+            except ValueError:
+                errors.append("DPI must be a positive integer.")
+                dpi = 300
+
+            if not errors and upload is not None:
+                try:
+                    template_obj = _parse_template(upload)
+                    image = builder.build_sheet(
+                        template_obj,
+                        dpi=dpi,
+                        show_option_guides=show_guides,
+                    )
+                    run_dir = _create_run_dir("build")
+                    filename = secure_filename(f"rendered_{dpi}dpi.png") or "rendered.png"
+                    image_path = run_dir / filename
+                    image.save(image_path)
+                    rel_path = _relative_to_output(image_path)
+                    result_context = {
+                        "path": str(image_path),
+                        "download_url": url_for("download_file", filename=rel_path),
+                        "preview_url": url_for("serve_file", filename=rel_path),
+                        "dpi": dpi,
+                        "template_name": template_obj.name,
+                    }
+                except Exception as exc:  # pragma: no cover - caught for user feedback
+                    errors.append(f"Failed to render template: {exc}")
+
+        return render_template(
+            "build.html",
+            title="Render a Template",
+            active_page="build",
+            errors=errors,
+            result=result_context,
+            form_values={
+                "dpi": dpi_value,
+                "show_option_guides": show_guides,
+            },
+        )
+
+    @app.route("/grade", methods=["GET", "POST"])
+    def grade_sheet() -> str:
+        errors: List[str] = []
+        result_context: Dict[str, object] | None = None
+        threshold_value = request.form.get("threshold", "0.5")
+
+        if request.method == "POST":
+            template_upload = request.files.get("template_file")
+            image_upload = request.files.get("image_file")
+            try:
+                threshold = float(threshold_value)
+            except ValueError:
+                errors.append("Threshold must be a number between 0 and 1.")
+                threshold = 0.5
+
+            if template_upload is None or template_upload.filename == "":
+                errors.append("A template JSON file is required.")
+            if image_upload is None or image_upload.filename == "":
+                errors.append("A scanned sheet image is required.")
+
+            if not errors and template_upload is not None and image_upload is not None:
+                try:
+                    template_obj = _parse_template(template_upload)
+                    image_data = image_upload.read()
+                    pil_image = Image.open(io.BytesIO(image_data))
+                except Exception as exc:  # pragma: no cover - surfaced to user
+                    errors.append(f"Failed to read inputs: {exc}")
+                else:
+                    try:
+                        try:
+                            results = evaluator.evaluate(
+                                template_obj, pil_image, threshold=threshold
+                            )
+                        finally:
+                            pil_image.close()
+                        run_dir = _create_run_dir("grade")
+                        json_path = run_dir / "evaluation_results.json"
+                        serialised = {
+                            f"{question}:{option}": filled
+                            for (question, option), filled in results.items()
+                        }
+                        json_path.write_text(json.dumps(serialised, indent=2, sort_keys=True), encoding="utf-8")
+                        rel_path = _relative_to_output(json_path)
+                        result_context = {
+                            "summary": _build_question_summary(template_obj, results),
+                            "download_url": url_for("download_file", filename=rel_path),
+                            "raw_url": url_for("serve_file", filename=rel_path),
+                            "threshold": threshold,
+                            "total_marked": sum(results.values()),
+                            "total_bubbles": len(results),
+                            "template_name": template_obj.name,
+                        }
+                    except Exception as exc:  # pragma: no cover - surfaced to user
+                        errors.append(f"Failed to evaluate scan: {exc}")
+
+        return render_template(
+            "grade.html",
+            title="Grade a Scan",
+            active_page="grade",
+            errors=errors,
+            result=result_context,
+            form_values={"threshold": threshold_value},
+        )
+
+    @app.route("/demo", methods=["GET", "POST"])
+    def demo_assets() -> str:
+        errors: List[str] = []
+        result_context: Dict[str, object] | None = None
+        seed_value = request.form.get("seed", "1234")
+
+        if request.method == "POST":
+            try:
+                seed = int(seed_value)
+            except ValueError:
+                errors.append("Seed must be an integer.")
+                seed = 1234
+
+            if not errors:
+                run_dir = _create_run_dir("demo")
+                try:
+                    artefacts = demo.generate_demo_assets(run_dir, seed=seed)
+                    files = [
+                        ("Template JSON", artefacts.template_path),
+                        ("Blank Sheet", artefacts.sheet_path),
+                        ("Filled Sheet", artefacts.filled_sheet_path),
+                        ("Evaluation Overlay", artefacts.evaluation_image_path),
+                        ("Evaluation Report", artefacts.evaluation_report_path),
+                    ]
+                    file_entries = [
+                        {
+                            "label": label,
+                            "path": str(path),
+                            "preview_url": url_for("serve_file", filename=_relative_to_output(path)),
+                            "download_url": url_for("download_file", filename=_relative_to_output(path)),
+                        }
+                        for label, path in files
+                    ]
+                    result_context = {
+                        "files": file_entries,
+                        "seed": seed,
+                        "base_dir": str(artefacts.base_dir),
+                    }
+                except Exception as exc:  # pragma: no cover - surfaced to user
+                    errors.append(f"Failed to generate demo artefacts: {exc}")
+
+        return render_template(
+            "demo.html",
+            title="Generate Demo Artefacts",
+            active_page="demo",
+            errors=errors,
+            result=result_context,
+            form_values={"seed": seed_value},
+        )
+
+    @app.route("/files/<path:filename>")
+    def serve_file(filename: str) -> Response:
+        return _serve_path(filename, as_attachment=False)
+
+    @app.route("/download/<path:filename>")
+    def download_file(filename: str) -> Response:
+        return _serve_path(filename, as_attachment=True)
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "numpy",
   "opencv-python",
   "click",
+  "Flask",
 ]
 
 [project.scripts]
@@ -21,6 +22,9 @@ omr = "omr.cli:main"
 
 [tool.setuptools.packages.find]
 include = ["omr"]
+
+[tool.setuptools.package-data]
+"omr" = ["templates/*.html"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Pillow
 numpy
 opencv-python
 click
+Flask

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from omr import builder, template
+from omr.webapp import create_app
+
+
+def _load_template_bytes() -> bytes:
+    template_path = Path(__file__).resolve().parent.parent / "template.json"
+    return template_path.read_bytes()
+
+
+def test_index_page_lists_workflows(tmp_path: Path) -> None:
+    app = create_app(output_dir=tmp_path)
+    app.config.update(TESTING=True)
+    client = app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b"Available workflows" in response.data
+
+
+def test_build_endpoint_renders_sheet(tmp_path: Path) -> None:
+    app = create_app(output_dir=tmp_path)
+    app.config.update(TESTING=True)
+    client = app.test_client()
+
+    data = {
+        "dpi": "150",
+        "show_option_guides": "on",
+        "template_file": (io.BytesIO(_load_template_bytes()), "template.json"),
+    }
+    response = client.post("/build", data=data, content_type="multipart/form-data")
+
+    assert response.status_code == 200
+    assert b"Rendered sheet" in response.data
+    saved = list(tmp_path.rglob("*.png"))
+    assert saved, "expected rendered image to be written to disk"
+
+
+def test_grade_endpoint_evaluates_scan(tmp_path: Path) -> None:
+    app = create_app(output_dir=tmp_path)
+    app.config.update(TESTING=True)
+    client = app.test_client()
+
+    tmpl = template.Template.from_json(_load_template_bytes().decode("utf-8"))
+    sheet = builder.build_sheet(tmpl, dpi=120)
+    buffer = io.BytesIO()
+    sheet.save(buffer, format="PNG")
+    sheet.close()
+    buffer.seek(0)
+
+    data = {
+        "threshold": "0.6",
+        "template_file": (io.BytesIO(_load_template_bytes()), "template.json"),
+        "image_file": (buffer, "scan.png"),
+    }
+    response = client.post("/grade", data=data, content_type="multipart/form-data")
+
+    assert response.status_code == 200
+    assert b"Evaluation summary" in response.data
+    assert b"No marks detected" in response.data
+    saved = list(tmp_path.rglob("evaluation_results.json"))
+    assert saved, "expected evaluation report to be saved"
+    report = json.loads(saved[0].read_text())
+    assert "Q1:A" in report
+
+
+def test_demo_endpoint_generates_bundle(tmp_path: Path) -> None:
+    app = create_app(output_dir=tmp_path)
+    app.config.update(TESTING=True)
+    client = app.test_client()
+
+    response = client.post("/demo", data={"seed": "42"})
+
+    assert response.status_code == 200
+    assert b"Demo bundle ready" in response.data
+    artefacts = list(tmp_path.rglob("modern_exam_template.json"))
+    assert artefacts, "expected demo artefacts to be written"


### PR DESCRIPTION
## Summary
- add a Flask-based web dashboard to trigger render, grade, and demo flows with file downloads
- create HTML templates for each workflow and shared styling for a simple navigation UI
- document the dashboard in the README and add automated endpoint tests plus package data configuration

## Testing
- ❌ `pytest` *(fails: ModuleNotFoundError: No module named 'flask' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4226e2fc4832ea79dab8394db1024