### PR TITLE
Ensure webapp artifact URLs use forward slashes

### DIFF
--- a/omr/webapp.py
+++ b/omr/webapp.py
@@ -33,7 +33,7 @@ def create_app(output_dir: Path | None = None) -> Flask:
         return run_dir
 
     def _relative_to_output(path: Path) -> str:
-        return str(path.relative_to(resolved_output))
+        return path.relative_to(resolved_output).as_posix()
 
     def _serve_path(filename: str, *, as_attachment: bool = False) -> Response:
         from flask import send_from_directory

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -79,5 +79,6 @@ def test_demo_endpoint_generates_bundle(tmp_path: Path) -> None:
 
     assert response.status_code == 200
     assert b"Demo bundle ready" in response.data
+    assert b"%5C" not in response.data
     artefacts = list(tmp_path.rglob("modern_exam_template.json"))
     assert artefacts, "expected demo artefacts to be written"


### PR DESCRIPTION
## Summary
- normalize generated file URLs in the web app to always use forward slashes
- add a regression test to ensure demo HTML responses never contain encoded backslashes in file links

## Testing
- pytest tests/test_webapp.py::test_demo_endpoint_generates_bundle

------
https://chatgpt.com/codex/tasks/task_e_68e4295c94d8832e8a2c5f2c8f7f52b1